### PR TITLE
Add imageUrl support for product operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ Para iniciar el servidor en modo desarrollo, ejecuta:
 npm run dev
 ```
 
+### Ejemplo de creación de producto
+
+Al enviar una solicitud `POST` a `/api/products`, puedes incluir el campo
+`imageUrl` junto con el resto de datos del producto. Ejemplo de payload:
+
+```json
+{
+  "name": "Pan artesanal",
+  "description": "Pan elaborado a mano",
+  "price": 3.5,
+  "stock": 10,
+  "imageUrl": "https://ejemplo.com/pan.png"
+}
+```
+
 ## Contribuciones
 
 Las contribuciones son bienvenidas. Por favor, abre un issue o envía un pull request para discutir cambios.

--- a/src/controllers/productController.js
+++ b/src/controllers/productController.js
@@ -49,8 +49,14 @@ exports.getProductById = async (req, res, next) => {
 // @access  Privado (admin)
 exports.createProduct = async (req, res, next) => {
   try {
-    const { name, description, price, stock } = req.body;
-    const newProduct = await Product.create({ name, description, price, stock });
+    const { name, description, price, stock, imageUrl } = req.body;
+    const newProduct = await Product.create({
+      name,
+      description,
+      price,
+      stock,
+      imageUrl,
+    });
     res.status(201).json(newProduct);
   } catch (err) {
     next(err);
@@ -62,9 +68,9 @@ exports.createProduct = async (req, res, next) => {
 // @access  Privado (admin)
 exports.updateProduct = async (req, res, next) => {
   try {
-    const { name, description, price, stock } = req.body;
+    const { name, description, price, stock, imageUrl } = req.body;
     const [updated] = await Product.update(
-      { name, description, price, stock },
+      { name, description, price, stock, imageUrl },
       { where: { id: req.params.id } }
     );
     if (!updated) {


### PR DESCRIPTION
## Summary
- support `imageUrl` on product creation and update
- document new payload example including `imageUrl`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f0ce208e0832482ed5919b9d7322c