### PR TITLE
Fix orders API response formatting

### DIFF
--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -9,6 +9,28 @@ const OrderItem       = require('../models/OrderItem');
 const Product         = require('../models/Product');
 const Customer        = require('../models/Customer'); // o User si usas User
 
+// Convierte ids numéricos a strings para evitar errores en el frontend
+const formatOrder = (ord) => {
+  if (!ord) return ord;
+  const plain = ord.get ? ord.get({ plain: true }) : ord;
+  plain.id = plain.id.toString();
+  if (plain.customerId !== undefined) plain.customerId = String(plain.customerId);
+  if (plain.Customer) {
+    plain.Customer.id = String(plain.Customer.id);
+  }
+  if (Array.isArray(plain.OrderItems)) {
+    plain.OrderItems = plain.OrderItems.map((it) => {
+      const item = it.get ? it.get({ plain: true }) : it;
+      item.id = String(item.id);
+      if (item.orderId !== undefined) item.orderId = String(item.orderId);
+      if (item.productId !== undefined) item.productId = String(item.productId);
+      if (item.Product) item.Product.id = String(item.Product.id);
+      return item;
+    });
+  }
+  return plain;
+};
+
 // Crear un nuevo pedido
 exports.createOrder = async (req, res) => {
   const { items, customerInfo, paymentMethod } = req.body;
@@ -81,7 +103,16 @@ exports.createOrder = async (req, res) => {
       });
     });
 
-    return res.status(201).json(result);
+    const formatted = formatOrder(result);
+    const resumen = formatted.OrderItems
+      .map((it) => `${it.quantity}x ${it.Product.name}`)
+      .join(', ');
+    return res.status(201).json({
+      ...formatted,
+      message:
+        'Pedido registrado. Espera confirmaci\u00f3n de la tienda para su preparaci\u00f3n.',
+      resumen,
+    });
   } catch (err) {
     console.error('Error en createOrder:', err);
     return res.status(500).json({ message: err.message || 'Error al crear orden' });
@@ -107,7 +138,7 @@ exports.getCustomerOrders = async (req, res) => {
       ],
       order: [['createdAt','DESC']]
     });
-    return res.json(orders);
+    return res.json(orders.map(formatOrder));
   } catch (err) {
     console.error('Error en getCustomerOrders:', err);
     return res.status(500).json({ message: 'Error al obtener órdenes' });
@@ -136,7 +167,7 @@ exports.getAllOrders = async (req, res) => {
       ],
       order: [['createdAt','DESC']]
     });
-    return res.json(orders);
+    return res.json(orders.map(formatOrder));
   } catch (err) {
     console.error('Error en getAllOrders:', err);
     return res.status(500).json({ message: 'Error al obtener órdenes' });
@@ -152,7 +183,14 @@ exports.updateOrderStatus = async (req, res) => {
     if (!order) return res.status(404).json({ message: 'Orden no encontrada' });
     order.status = status;
     await order.save();
-    return res.json(order);
+    const msg =
+      status === 'received'
+        ? 'La tienda ha recibido tu pedido y lo est\u00e1 preparando.'
+        : 'Estado actualizado';
+    return res.json({
+      ...formatOrder(order),
+      message: msg,
+    });
   } catch (err) {
     console.error('Error en updateOrderStatus:', err);
     return res.status(500).json({ message: 'Error al actualizar estado' });

--- a/src/models/Order.js
+++ b/src/models/Order.js
@@ -17,8 +17,8 @@ Order.init(
       allowNull: false
     },
     status: {
-      // Ajusta el ENUM a los valores de tu tipo PostgreSQL
-      type: DataTypes.ENUM('pending', 'delivered', 'cancelled'),
+      // Posibles estados del pedido
+      type: DataTypes.ENUM('pending', 'received', 'delivered', 'cancelled'),
       defaultValue: 'pending'
     },
     paymentMethod: {


### PR DESCRIPTION
## Summary
- include `received` in order status enum
- stringify order ids to avoid front‑end errors
- return order summary message when creating an order
- return confirmation message when updating status

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f19ab5cc48324ab9afb8ca54b968c