### PR TITLE
Add rejection handling in orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Al enviar una solicitud `POST` a `/api/products`, puedes incluir el campo
 }
 ```
 
+### Actualizar estado de un pedido
+
+Para cambiar el estado de una orden envía una solicitud `PUT` a
+`/api/orders/:id/status` con un cuerpo JSON que incluya el nuevo `status`.
+Los valores permitidos son `pending`, `received`, `delivered`, `cancelled` y
+`rejected`. Si el estado es `rejected` puedes incluir un campo opcional
+`reason` que será almacenado como `rejectionReason`.
+
 ## Contribuciones
 
 Las contribuciones son bienvenidas. Por favor, abre un issue o envía un pull request para discutir cambios.

--- a/src/models/Order.js
+++ b/src/models/Order.js
@@ -18,8 +18,18 @@ Order.init(
     },
     status: {
       // Posibles estados del pedido
-      type: DataTypes.ENUM('pending', 'received', 'delivered', 'cancelled'),
+      type: DataTypes.ENUM(
+        'pending',
+        'received',
+        'delivered',
+        'cancelled',
+        'rejected'
+      ),
       defaultValue: 'pending'
+    },
+    rejectionReason: {
+      type: DataTypes.TEXT,
+      allowNull: true
     },
     paymentMethod: {
       type: DataTypes.STRING(20),


### PR DESCRIPTION
## Summary
- allow `rejected` status with reason in Order model
- validate status updates and store rejection reason
- expose `rejectionReason` in formatted orders
- document new behaviour for updating order status

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850fa66a04c8324bda2b009c3fc275f