### PR TITLE
Add customer info on registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ Para iniciar el servidor en modo desarrollo, ejecuta:
 npm run dev
 ```
 
+### Registro de usuario
+
+Para crear una cuenta envía un `POST` a `/api/auth/register` con los campos
+`name`, `email`, `password`, `phone` y `address`:
+
+```json
+{
+  "name": "Juan",
+  "email": "juan@example.com",
+  "password": "secreto",
+  "phone": "555-1234",
+  "address": "Calle Principal 123"
+}
+```
+
 ### Ejemplo de creación de producto
 
 Al enviar una solicitud `POST` a `/api/products`, puedes incluir el campo

--- a/src/models/Customer.js
+++ b/src/models/Customer.js
@@ -37,3 +37,7 @@ const Customer = sequelize.define('Customer', {
 });
 
 module.exports = Customer;
+
+// Asociación 1:1 con User
+const User = require('./User');
+Customer.belongsTo(User, { foreignKey: 'id', as: 'user' });

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -42,3 +42,7 @@ const User = sequelize.define('User', {
 });
 
 module.exports = User;
+
+// Asociación 1:1 con Customer
+const Customer = require('./Customer');
+User.hasOne(Customer, { foreignKey: 'id', as: 'customer' });


### PR DESCRIPTION
## Summary
- register customers with phone and address
- expose contact info on login
- document registration fields
- link `User` and `Customer` models

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851d3b3b3c48324a2783aee165c999e