### PR TITLE
Add order modification endpoint

### DIFF
--- a/src/routes/orderRoutes.js
+++ b/src/routes/orderRoutes.js
@@ -9,6 +9,7 @@ const {
   getCustomerOrders,
   getAllOrders,
   updateOrderStatus,
+  modifyOrder,
   getOrderById,
   deleteOrder
 } = require('../controllers/orderController');
@@ -20,7 +21,7 @@ router.post('/',           createOrder);
 router.get('/',            protect,           getCustomerOrders);
 router.get('/all',         protect,    isAdmin, getAllOrders);
 router.put('/:id/status',  protect,    isAdmin, updateOrderStatus);
-router.patch('/:id',       protect,    isAdmin, updateOrderStatus);
+router.patch('/:id',       protect,           modifyOrder);
 router.delete('/:id',      protect,           deleteOrder);
 router.get('/:id',         protect,           getOrderById);
 


### PR DESCRIPTION
## Summary
- allow customers to modify or cancel their own pending orders
- emit SSE updates when orders change

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851d4dccf2883248a853d9e26a9f91b