### PR TITLE
Add category and imageUrl support

### DIFF
--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -99,7 +99,7 @@ exports.createOrder = async (req, res) => {
           {
             model: OrderItem,
             as: 'OrderItems',
-            include: [{ model: Product, as: 'Product', attributes: ['id', 'name', 'price'] }]
+            include: [{ model: Product, as: 'Product', attributes: ['id', 'name', 'price', 'category', 'imageUrl'] }]
           },
           {
             model: Customer,
@@ -138,7 +138,7 @@ exports.getCustomerOrders = async (req, res) => {
         include: [{
           model: Product,
           as: 'Product',
-          attributes: ['id', 'name', 'price']
+          attributes: ['id', 'name', 'price', 'category', 'imageUrl']
         }]
       }
     ];
@@ -171,7 +171,7 @@ exports.getAllOrders = async (req, res) => {
         include: [{
           model: Product,
           as: 'Product',
-          attributes: ['id', 'name', 'price']
+          attributes: ['id', 'name', 'price', 'category', 'imageUrl']
         }]
       }
     ];
@@ -288,7 +288,7 @@ exports.modifyOrder = async (req, res) => {
           model: OrderItem,
           as: 'OrderItems',
           include: [
-            { model: Product, as: 'Product', attributes: ['id', 'name', 'price'] }
+            { model: Product, as: 'Product', attributes: ['id', 'name', 'price', 'category', 'imageUrl'] }
           ]
         },
         {
@@ -317,7 +317,7 @@ exports.getOrderById = async (req, res) => {
         include: [{
           model: Product,
           as: 'Product',
-          attributes: ['id', 'name', 'price']
+          attributes: ['id', 'name', 'price', 'category', 'imageUrl']
         }]
       }
     ];

--- a/src/controllers/productController.js
+++ b/src/controllers/productController.js
@@ -16,7 +16,9 @@ exports.getAllProducts = async (req, res, next) => {
         'name',
         'description',
         'price',
-        'stock',       // Asegúrate de que este campo exista en tu modelo
+        'stock',
+        'category',
+        'imageUrl',
         'createdAt',
         'updatedAt'
       ]
@@ -33,7 +35,7 @@ exports.getAllProducts = async (req, res, next) => {
 exports.getProductById = async (req, res, next) => {
   try {
     const product = await Product.findByPk(req.params.id, {
-      attributes: ['id', 'name', 'description', 'price', 'stock']
+      attributes: ['id', 'name', 'description', 'price', 'stock', 'category', 'imageUrl']
     });
     if (!product) {
       return res.status(404).json({ message: 'Producto no encontrado' });
@@ -49,12 +51,13 @@ exports.getProductById = async (req, res, next) => {
 // @access  Privado (admin)
 exports.createProduct = async (req, res, next) => {
   try {
-    const { name, description, price, stock, imageUrl } = req.body;
+    const { name, description, price, stock, category, imageUrl } = req.body;
     const newProduct = await Product.create({
       name,
       description,
       price,
       stock,
+      category,
       imageUrl,
     });
     res.status(201).json(newProduct);
@@ -68,9 +71,9 @@ exports.createProduct = async (req, res, next) => {
 // @access  Privado (admin)
 exports.updateProduct = async (req, res, next) => {
   try {
-    const { name, description, price, stock, imageUrl } = req.body;
+    const { name, description, price, stock, category, imageUrl } = req.body;
     const [updated] = await Product.update(
-      { name, description, price, stock, imageUrl },
+      { name, description, price, stock, category, imageUrl },
       { where: { id: req.params.id } }
     );
     if (!updated) {

--- a/src/routes/productRoutes.js
+++ b/src/routes/productRoutes.js
@@ -28,6 +28,7 @@ router.post(
     description: { required: true },
     price: { required: true, type: 'number' },
     stock: { required: true, type: 'integer' },
+    category: { required: true },
     imageUrl: {}
   }),
   productController.createProduct
@@ -43,6 +44,7 @@ router.put(
     description: {},
     price: { type: 'number' },
     stock: { type: 'integer' },
+    category: {},
     imageUrl: {}
   }),
   productController.updateProduct


### PR DESCRIPTION
## Summary
- return `category` and `imageUrl` from product endpoints
- include product `category` and `imageUrl` in orders
- validate `category` field in product routes

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68525364f15c8324a15fd1fa38ab3b4d