### PR TITLE
Translate product categories for users

### DIFF
--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -9,6 +9,7 @@ const OrderItem       = require('../models/OrderItem');
 const Product         = require('../models/Product');
 const Customer        = require('../models/Customer'); // o User si usas User
 const orderEvents     = require('../utils/orderEvents');
+const { toSpanish }   = require('../utils/categoryTranslations');
 
 const allowedStatuses = Order.rawAttributes.status.values;
 
@@ -28,7 +29,10 @@ const formatOrder = (ord) => {
       item.id = String(item.id);
       if (item.orderId !== undefined) item.orderId = String(item.orderId);
       if (item.productId !== undefined) item.productId = String(item.productId);
-      if (item.Product) item.Product.id = String(item.Product.id);
+      if (item.Product) {
+        item.Product.id = String(item.Product.id);
+        item.Product.categoryName = toSpanish(item.Product.category);
+      }
       return item;
     });
   }

--- a/src/controllers/productController.js
+++ b/src/controllers/productController.js
@@ -4,6 +4,7 @@
 // - getAllProducts, getProductById, createProduct, updateProduct, deleteProduct
 
 const Product = require('../models/Product');
+const { toSpanish } = require('../utils/categoryTranslations');
 
 // @route   GET /api/products
 // @desc    Obtener todos los productos
@@ -23,7 +24,12 @@ exports.getAllProducts = async (req, res, next) => {
         'updatedAt'
       ]
     });
-    res.json(products);
+    const translated = products.map(p => {
+      const plain = p.get({ plain: true });
+      plain.categoryName = toSpanish(plain.category);
+      return plain;
+    });
+    res.json(translated);
   } catch (err) {
     next(err);
   }
@@ -40,7 +46,9 @@ exports.getProductById = async (req, res, next) => {
     if (!product) {
       return res.status(404).json({ message: 'Producto no encontrado' });
     }
-    res.json(product);
+    const plain = product.get({ plain: true });
+    plain.categoryName = toSpanish(plain.category);
+    res.json(plain);
   } catch (err) {
     next(err);
   }
@@ -60,7 +68,9 @@ exports.createProduct = async (req, res, next) => {
       category,
       imageUrl,
     });
-    res.status(201).json(newProduct);
+    const plain = newProduct.get({ plain: true });
+    plain.categoryName = toSpanish(plain.category);
+    res.status(201).json(plain);
   } catch (err) {
     next(err);
   }
@@ -80,7 +90,9 @@ exports.updateProduct = async (req, res, next) => {
       return res.status(404).json({ message: 'Producto no encontrado' });
     }
     const updatedProduct = await Product.findByPk(req.params.id);
-    res.json(updatedProduct);
+    const plain = updatedProduct.get({ plain: true });
+    plain.categoryName = toSpanish(plain.category);
+    res.json(plain);
   } catch (err) {
     next(err);
   }

--- a/src/utils/categoryTranslations.js
+++ b/src/utils/categoryTranslations.js
@@ -1,0 +1,12 @@
+const translations = {
+  bread: 'Pan',
+  sweet: 'Dulce',
+  special: 'Especial',
+  general: 'General'
+};
+
+function toSpanish(key) {
+  return translations[key] || key;
+}
+
+module.exports = { toSpanish };


### PR DESCRIPTION
## Summary
- add category translation utility
- show Spanish category names when returning product info
- include Spanish category names inside orders

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68525811ea4c8324bf2fd1c62f399e84