### PR TITLE
Add category endpoint and stock update route

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ Al enviar una solicitud `POST` a `/api/products`, puedes incluir el campo
 }
 ```
 
+### Obtener categorías disponibles
+
+Envía una petición `GET` a `/api/products/categories` para obtener las categorías
+de productos en español.
+
+### Actualizar solo el stock de un producto
+
+Para modificar únicamente la cantidad disponible utiliza
+`PATCH /api/products/:id/stock` enviando un JSON con el campo `stock` (entero
+mayor o igual a 0).
+
 ### Actualizar estado de un pedido
 
 Para cambiar el estado de una orden envía una solicitud `PUT` a

--- a/src/middleware/validate.js
+++ b/src/middleware/validate.js
@@ -39,6 +39,11 @@ function validate(schema = {}) {
       if (rules.regex && typeof value === 'string' && !rules.regex.test(value)) {
         errors.push(`${field} is invalid`);
       }
+
+      // Minimum value validation
+      if (rules.min !== undefined && Number(value) < rules.min) {
+        errors.push(`${field} must be >= ${rules.min}`);
+      }
     }
 
     if (errors.length) {

--- a/src/models/Product.js
+++ b/src/models/Product.js
@@ -31,6 +31,7 @@ const Product = sequelize.define('Product', {
     type: DataTypes.INTEGER,
     allowNull: false,
     defaultValue: 0,
+    validate: { min: 0 },
   },
   category: {
     type: DataTypes.STRING(50),

--- a/src/routes/productRoutes.js
+++ b/src/routes/productRoutes.js
@@ -14,6 +14,9 @@ const { protect, isAdmin } = require('../middleware/authMiddleware');
 // GET /api/products          → Lista todos los productos
 router.get('/', productController.getAllProducts);
 
+// GET /api/products/categories → Lista de categorías en español
+router.get('/categories', productController.getCategories);
+
 // GET /api/products/:id      → Detalle de un producto
 router.get('/:id', productController.getProductById);
 
@@ -27,7 +30,7 @@ router.post(
     name: { required: true },
     description: { required: true },
     price: { required: true, type: 'number' },
-    stock: { required: true, type: 'integer' },
+    stock: { required: true, type: 'integer', min: 0 },
     category: { required: true },
     imageUrl: {}
   }),
@@ -43,7 +46,7 @@ router.put(
     name: {},
     description: {},
     price: { type: 'number' },
-    stock: { type: 'integer' },
+    stock: { type: 'integer', min: 0 },
     category: {},
     imageUrl: {}
   }),
@@ -52,5 +55,14 @@ router.put(
 
 // DELETE /api/products/:id   → Eliminar producto
 router.delete('/:id', protect, isAdmin, productController.deleteProduct);
+
+// PATCH /api/products/:id/stock → Actualizar solo el stock
+router.patch(
+  '/:id/stock',
+  protect,
+  isAdmin,
+  validate({ stock: { required: true, type: 'integer', min: 0 } }),
+  productController.updateProductStock
+);
 
 module.exports = router;

--- a/src/utils/categoryLabels.js
+++ b/src/utils/categoryLabels.js
@@ -1,0 +1,8 @@
+const categoryLabels = {
+  bread: 'Pan',
+  sweet: 'Postres',
+  special: 'Especial',
+  general: 'General'
+};
+
+module.exports = categoryLabels;


### PR DESCRIPTION
## Summary
- revert previous category name translations
- add middleware validation for minimum values
- enforce non-negative stock in model and controllers
- expose product categories in Spanish via new endpoint
- add admin route to update product stock quickly

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68525811ea4c8324bf2fd1c62f399e84