### PR TITLE
Add preparing and ready order statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Al enviar una solicitud `POST` a `/api/products`, puedes incluir el campo
 
 Para cambiar el estado de una orden envía una solicitud `PUT` a
 `/api/orders/:id/status` con un cuerpo JSON que incluya el nuevo `status`.
-Los valores permitidos son `pending`, `received`, `delivered`, `cancelled` y
-`rejected`. Si el estado es `rejected` puedes incluir un campo opcional
+Los valores permitidos son `pending`, `received`, `preparing`, `ready`,
+`delivered`, `cancelled` y `rejected`. Si el estado es `rejected` puedes incluir un campo opcional
 `reason` que será almacenado como `rejectionReason`.
 
 ## Contribuciones

--- a/src/models/Order.js
+++ b/src/models/Order.js
@@ -21,6 +21,8 @@ Order.init(
       type: DataTypes.ENUM(
         'pending',
         'received',
+        'preparing',
+        'ready',
         'delivered',
         'cancelled',
         'rejected'


### PR DESCRIPTION
## Summary
- support new order states `preparing` and `ready` in the `Order` model
- document the extra states in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853157c281883249c5d3b97d367281b