### PR TITLE
Fix order status route duplication

### DIFF
--- a/src/routes/orderRoutes.js
+++ b/src/routes/orderRoutes.js
@@ -25,17 +25,9 @@ router.post(
 );
 router.get('/',            protect,           getCustomerOrders);
 router.get('/all',         protect,    isAdmin, getAllOrders);
-router.put('/:id/status',  protect,    isAdmin, updateOrderStatus);
-router.patch('/:id',       protect,           modifyOrder);
+router.patch('/:id', protect, modifyOrder);
 router.put(
   '/:id/status',
-  protect,
-  isAdmin,
-  validate({ status: { required: true } }),
-  updateOrderStatus
-);
-router.patch(
-  '/:id',
   protect,
   isAdmin,
   validate({ status: { required: true } }),


### PR DESCRIPTION
## Summary
- remove duplicate admin routes for updating order status
- keep only the PATCH route for customers and PUT `/api/orders/:id/status` for admins

## Testing
- `npm start` *(fails: Cannot find module 'cookie-parser')*

------
https://chatgpt.com/codex/tasks/task_e_6853386c39b483248a01e67502b76603