### PR TITLE
Relate orders to users

### DIFF
--- a/migrations/20230619-rename-customerId-to-userId.js
+++ b/migrations/20230619-rename-customerId-to-userId.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.renameColumn('orders', 'customerId', 'userId');
+    await queryInterface.changeColumn('orders', 'userId', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'users',
+        key: 'id'
+      },
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.renameColumn('orders', 'userId', 'customerId');
+    await queryInterface.changeColumn('orders', 'customerId', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'customers',
+        key: 'id'
+      },
+    });
+  }
+};

--- a/src/models/Order.js
+++ b/src/models/Order.js
@@ -1,6 +1,7 @@
 // src/models/Order.js
 const { Model, DataTypes } = require('sequelize');
 const sequelize  = require('../config/database');
+const User       = require('./User');
 const Customer   = require('./Customer');
 const OrderItem  = require('./OrderItem');
 
@@ -45,11 +46,10 @@ Order.init(
       type: DataTypes.INTEGER, // minutos u otro
       allowNull: true
     },
-    customerId: {
-      // En tu tabla es customerId
+    userId: {
       type: DataTypes.INTEGER,
       allowNull: false,
-      field: 'customerId'
+      field: 'userId'
     }
   },
   {
@@ -64,9 +64,9 @@ Order.init(
 
 // Asociaciones
 
-// 1) Cliente ↔ Pedidos
-Customer.hasMany(Order,    { foreignKey: 'customerId', as: 'orders' });
-Order.belongsTo(Customer,  { foreignKey: 'customerId', as: 'Customer' });
+// 1) Usuario ↔ Pedidos
+User.hasMany(Order,    { foreignKey: 'userId', as: 'orders' });
+Order.belongsTo(User,  { foreignKey: 'userId', as: 'User' });
 
 // 2) Pedido ↔ Líneas de pedido
 Order.hasMany(OrderItem,   { foreignKey: 'orderId', as: 'OrderItems' });

--- a/src/routes/orderRoutes.js
+++ b/src/routes/orderRoutes.js
@@ -17,9 +17,9 @@ const { protect, isAdmin } = require('../middleware/authMiddleware');
 const validate = require('../middleware/validate');
 
 // Rutas de pedidos
-// Se permite POST sin JWT para invitado (createOrder internamente gestiona guest)
 router.post(
   '/',
+  protect,
   validate({ items: { required: true, type: 'array' }, paymentMethod: { required: true } }),
   createOrder
 );

--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,7 @@ const authRoutes    = require('./routes/authRoutes');
 const productRoutes = require('./routes/productRoutes');
 const orderRoutes   = require('./routes/orderRoutes');
 const userRoutes    = require('./routes/userRoutes');
+const { protect }   = require('./middleware/authMiddleware');
 // … cualquier otro router …
 
 // Crea la app
@@ -35,7 +36,7 @@ app.use('/api/auth',     authRoutes);
 app.use('/api/products',  productRoutes);
 app.use('/api/orders',    orderRoutes);
 app.use('/api/users',     userRoutes);
-app.get('/api/orders/stream', (req, res) => {
+app.get('/api/orders/stream', protect, (req, res) => {
   orderEvents.register(res);
 });
 // … monta aquí el resto de tus rutas …


### PR DESCRIPTION
## Summary
- link orders to users via `userId`
- secure all order routes
- use authenticated user in createOrder and queries
- protect orders stream endpoint
- add migration to rename `customerId` to `userId`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853872e2adc83249039e08564e26f03