### PR TITLE
Add phone/address to profile endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ Los valores permitidos son `pending`, `received`, `preparing`, `ready`,
 `delivered`, `cancelled` y `rejected`. Si el estado es `rejected` puedes incluir un campo opcional
 `reason` que será almacenado como `rejectionReason`.
 
+### Perfil de usuario
+
+Un usuario autenticado puede obtener o modificar su perfil accediendo al
+endpoint `/api/users/profile`.
+
+- **GET `/api/users/profile`**: devuelve un objeto con los campos `id`,
+  `name`, `email`, `role`, `createdAt`, `phone` y `address`.
+- **PUT `/api/users/profile`**: actualiza los datos de `name`, `phone`,
+  `email` y `address`.
+
+Esto permite que el frontend rellene automáticamente la información de
+contacto al crear una orden.
+
 ## Contribuciones
 
 Las contribuciones son bienvenidas. Por favor, abre un issue o envía un pull request para discutir cambios.

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -3,18 +3,27 @@
 const User = require('../models/User');
 const Customer = require('../models/Customer');
 
-// Obtener el perfil del usuario autenticado junto con sus datos de Customer
+// Obtener el perfil del usuario autenticado unificando datos de User y Customer
 exports.getProfile = async (req, res) => {
   try {
     const user = await User.findByPk(req.user.id, {
-      attributes: ['id', 'name', 'email', 'role', 'createdAt', 'updatedAt'],
+      attributes: ['id', 'name', 'email', 'role', 'createdAt'],
     });
     if (!user) {
       return res.status(404).json({ message: 'Usuario no encontrado' });
     }
 
     const customer = await Customer.findByPk(req.user.id);
-    return res.json({ user, customer });
+
+    return res.json({
+      id: String(user.id),
+      name: user.name,
+      email: user.email,
+      role: user.role,
+      createdAt: user.createdAt.toISOString(),
+      phone: customer ? customer.phone : null,
+      address: customer ? customer.address : null,
+    });
   } catch (err) {
     console.error('Error getProfile:', err);
     return res.status(500).json({ message: 'Error al obtener perfil' });
@@ -45,10 +54,18 @@ exports.updateProfile = async (req, res) => {
     }
 
     const user = await User.findByPk(userId, {
-      attributes: ['id', 'name', 'email', 'role', 'createdAt', 'updatedAt'],
+      attributes: ['id', 'name', 'email', 'role', 'createdAt'],
     });
 
-    return res.json({ user, customer });
+    return res.json({
+      id: String(user.id),
+      name: user.name,
+      email: user.email,
+      role: user.role,
+      createdAt: user.createdAt.toISOString(),
+      phone: customer.phone,
+      address: customer.address,
+    });
   } catch (err) {
     console.error('Error updateProfile:', err);
     return res.status(500).json({ message: 'Error al actualizar perfil' });


### PR DESCRIPTION
## Summary
- unify profile responses to include phone and address information
- document the new `/api/users/profile` behaviour in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68539f1aed808324a5bc99951bd0b0d3