### PR TITLE
Add isDelivery support for orders

### DIFF
--- a/migrations/20230622-add-isDelivery-to-orders.js
+++ b/migrations/20230622-add-isDelivery-to-orders.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('orders', 'isDelivery', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('orders', 'isDelivery');
+  }
+};

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -38,7 +38,7 @@ const formatOrder = (ord) => {
 
 // Crear un nuevo pedido
 exports.createOrder = async (req, res) => {
-  const { items, paymentMethod } = req.body;
+  const { items, paymentMethod, isDelivery } = req.body;
   if (!Array.isArray(items) || items.length === 0) {
     return res.status(400).json({ message: 'Datos de orden incompletos' });
   }
@@ -48,7 +48,7 @@ exports.createOrder = async (req, res) => {
 
       // 1) Crear la orden inicial
       const order = await Order.create(
-        { userId, status: 'pending', paymentMethod, total: 0 },
+        { userId, status: 'pending', paymentMethod, isDelivery, total: 0 },
         { transaction: tx }
       );
 

--- a/src/models/Order.js
+++ b/src/models/Order.js
@@ -40,6 +40,7 @@ Order.init(
     },
     isDelivery: {
       type: DataTypes.BOOLEAN,
+      allowNull: false,
       defaultValue: false
     },
     estimatedTime: {

--- a/src/routes/orderRoutes.js
+++ b/src/routes/orderRoutes.js
@@ -20,7 +20,11 @@ const validate = require('../middleware/validate');
 router.post(
   '/',
   protect,
-  validate({ items: { required: true, type: 'array' }, paymentMethod: { required: true } }),
+  validate({
+    items: { required: true, type: 'array' },
+    paymentMethod: { required: true },
+    isDelivery: { type: 'boolean' }
+  }),
   createOrder
 );
 router.get('/',            protect,           getCustomerOrders);


### PR DESCRIPTION
## Summary
- allow creating orders with `isDelivery` flag
- validate `isDelivery` when creating orders
- persist and expose the flag in the database

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685af51b0c008324a8ffb5b786733e35